### PR TITLE
Fix warnings with glibc >= 2.24, fixes #7.

### DIFF
--- a/src/unx/process.c
+++ b/src/unx/process.c
@@ -33,7 +33,7 @@
 */
 
 #if defined(__linux__) || defined(__GLIBC__) || defined(__GNU__)
-#define _XOPEN_SOURCE			/* GNU glibc grantpt() prototypes */
+#define _XOPEN_SOURCE 500 /* GNU glibc grantpt() prototypes */
 #endif
 #include <h/kernel.h>
 


### PR DESCRIPTION
Since glibc 2.24 `_XOPEN_SOURCE` has to be defined to 500 or higher for ptsname and grantpt.
Reason: This functions are new in XPG4, see also [glibc bugtracker](https://sourceware.org/bugzilla/show_bug.cgi?id=20094).

This information is still missing in the latest man pages.