### PR TITLE
Correct link in comment

### DIFF
--- a/prolog/boot/pce_keybinding.pl
+++ b/prolog/boot/pce_keybinding.pl
@@ -2,7 +2,7 @@
 
     Author:        Jan Wielemaker and Anjo Anjewierden
     E-mail:        J.Wielemaker@vu.nl
-    WWW:           http://www.swi-prolog.org/projects/xpce/
+    WWW:           http://www.swi-prolog.org/packages/xpce/
     Copyright (c)  2002-2013, University of Amsterdam
                               VU University Amsterdam
     All rights reserved.

--- a/prolog/boot/pce_pl.pl
+++ b/prolog/boot/pce_pl.pl
@@ -2,7 +2,7 @@
 
     Author:        Jan Wielemaker and Anjo Anjewierden
     E-mail:        J.Wielemaker@vu.nl
-    WWW:           http://www.swi-prolog.org/projects/xpce/
+    WWW:           http://www.swi-prolog.org/packages/xpce/
     Copyright (c)  1985-2020, University of Amsterdam
                               VU University Amsterdam
     All rights reserved.

--- a/prolog/demo/ispell.pl
+++ b/prolog/demo/ispell.pl
@@ -2,7 +2,7 @@
 
     Author:        Jan Wielemaker and Anjo Anjewierden
     E-mail:        J.Wielemaker@vu.nl
-    WWW:           http://www.swi-prolog.org/projects/xpce/
+    WWW:           http://www.swi-prolog.org/packages/xpce/
     Copyright (c)  1995-2015, University of Amsterdam
                               VU University Amsterdam
     All rights reserved.

--- a/prolog/demo/pce_demo.pl
+++ b/prolog/demo/pce_demo.pl
@@ -2,7 +2,7 @@
 
     Author:        Jan Wielemaker and Anjo Anjewierden
     E-mail:        J.Wielemaker@vu.nl.nl
-    WWW:           http://www.swi-prolog.org/projects/xpce/
+    WWW:           http://www.swi-prolog.org/packages/xpce/
     Copyright (c)  1995-2014, University of Amsterdam
                               VU University Amsterdam
     All rights reserved.

--- a/prolog/lib/emacs/application.pl
+++ b/prolog/lib/emacs/application.pl
@@ -2,7 +2,7 @@
 
     Author:        Jan Wielemaker and Anjo Anjewierden
     E-mail:        J.Wielemaker@cs.vu.nl
-    WWW:           http://www.swi-prolog.org/projects/xpce/
+    WWW:           http://www.swi-prolog.org/packages/xpce/
     Copyright (c)  1996-2018, University of Amsterdam
                               VU University Amsterdam
                               CWI, Amsterdam

--- a/prolog/lib/emacs/buffer.pl
+++ b/prolog/lib/emacs/buffer.pl
@@ -2,7 +2,7 @@
 
     Author:        Jan Wielemaker and Anjo Anjewierden
     E-mail:        J.Wielemaker@cs.vu.nl
-    WWW:           http://www.swi-prolog.org/projects/xpce/
+    WWW:           http://www.swi-prolog.org/packages/xpce/
     Copyright (c)  1985-2011, University of Amsterdam
                               VU University Amsterdam
     All rights reserved.

--- a/prolog/lib/emacs/javascript_mode.pl
+++ b/prolog/lib/emacs/javascript_mode.pl
@@ -2,7 +2,7 @@
 
     Author:        Jan Wielemaker and Anjo Anjewierden
     E-mail:        J.Wielemaker@cs.vu.nl
-    WWW:           http://www.swi-prolog.org/projects/xpce/
+    WWW:           http://www.swi-prolog.org/packages/xpce/
     Copyright (c)  2013-2014, VU University Amsterdam
     All rights reserved.
 

--- a/prolog/lib/emacs/language_mode.pl
+++ b/prolog/lib/emacs/language_mode.pl
@@ -2,7 +2,7 @@
 
     Author:        Jan Wielemaker and Anjo Anjewierden
     E-mail:        J.Wielemaker@cs.vu.nl
-    WWW:           http://www.swi-prolog.org/projects/xpce/
+    WWW:           http://www.swi-prolog.org/packages/xpce/
     Copyright (c)  1985-2018, University of Amsterdam
                               VU University Amsterdam
                               CWI, Amsterdam

--- a/prolog/lib/emacs/server.pl
+++ b/prolog/lib/emacs/server.pl
@@ -2,7 +2,7 @@
 
     Author:        Jan Wielemaker and Anjo Anjewierden
     E-mail:        J.Wielemaker@cs.vu.nl
-    WWW:           http://www.swi-prolog.org/projects/xpce/
+    WWW:           http://www.swi-prolog.org/packages/xpce/
     Copyright (c)  1985-2012, University of Amsterdam
                               VU University Amsterdam
     All rights reserved.

--- a/prolog/lib/emacs/swi_prolog.pl
+++ b/prolog/lib/emacs/swi_prolog.pl
@@ -2,7 +2,7 @@
 
     Author:        Jan Wielemaker and Anjo Anjewierden
     E-mail:        J.Wielemaker@cs.vu.nl
-    WWW:           http://www.swi-prolog.org/projects/xpce/
+    WWW:           http://www.swi-prolog.org/packages/xpce/
     Copyright (c)  1985-2011, University of Amsterdam
                               VU University Amsterdam
     All rights reserved.

--- a/prolog/lib/emacs/turtle_mode.pl
+++ b/prolog/lib/emacs/turtle_mode.pl
@@ -2,7 +2,7 @@
 
     Author:        Jan Wielemaker
     E-mail:        J.Wielemaker@vu.nl
-    WWW:           http://www.swi-prolog.org/projects/xpce/
+    WWW:           http://www.swi-prolog.org/packages/xpce/
     Copyright (c)  2011-2012, VU University Amsterdam
     All rights reserved.
 

--- a/prolog/lib/english/pce_messages.pl
+++ b/prolog/lib/english/pce_messages.pl
@@ -2,7 +2,7 @@
 
     Author:        Jan Wielemaker and Anjo Anjewierden
     E-mail:        J.Wielemaker@vu.nl
-    WWW:           http://www-swi-prolog.org/projects/xpce/
+    WWW:           http://www.swi-prolog.org/projects/xpce/
     Copyright (c)  1995-2014, University of Amsterdam
                               VU University Amsterdam
     All rights reserved.

--- a/prolog/lib/english/pce_messages.pl
+++ b/prolog/lib/english/pce_messages.pl
@@ -2,7 +2,7 @@
 
     Author:        Jan Wielemaker and Anjo Anjewierden
     E-mail:        J.Wielemaker@vu.nl
-    WWW:           http://www.swi-prolog.org/projects/xpce/
+    WWW:           http://www.swi-prolog.org/packages/xpce/
     Copyright (c)  1995-2014, University of Amsterdam
                               VU University Amsterdam
     All rights reserved.

--- a/prolog/lib/gui_tracer.pl
+++ b/prolog/lib/gui_tracer.pl
@@ -2,7 +2,7 @@
 
     Author:        Jan Wielemaker and Anjo Anjewierden
     E-mail:        J.Wielemaker@vu.nl
-    WWW:           http://www.swi-prolog.org/projects/xpce/
+    WWW:           http://www.swi-prolog.org/packages/xpce/
     Copyright (c)  2001-2015, University of Amsterdam
                               VU University Amsterdam
     All rights reserved.

--- a/prolog/lib/pce_manual.pl
+++ b/prolog/lib/pce_manual.pl
@@ -2,7 +2,7 @@
 
     Author:        Jan Wielemaker and Anjo Anjewierden
     E-mail:        J.Wielemaker@cs.vu.nl
-    WWW:           http://www.swi-prolog.org/projects/xpce/
+    WWW:           http://www.swi-prolog.org/packages/xpce/
     Copyright (c)  1985-2011, University of Amsterdam
                               VU University Amsterdam
     All rights reserved.

--- a/prolog/lib/pce_meta.pl
+++ b/prolog/lib/pce_meta.pl
@@ -2,7 +2,7 @@
 
     Author:        Jan Wielemaker and Anjo Anjewierden
     E-mail:        J.Wielemaker@vu.nl
-    WWW:           http://www.swi-prolog.org/projects/xpce/
+    WWW:           http://www.swi-prolog.org/packages/xpce/
     Copyright (c)  1999-2011, University of Amsterdam
                               VU University Amsterdam
     All rights reserved.

--- a/prolog/lib/pce_prolog_xref.pl
+++ b/prolog/lib/pce_prolog_xref.pl
@@ -2,7 +2,7 @@
 
     Author:        Jan Wielemaker and Anjo Anjewierden
     E-mail:        J.Wielemaker@vu.nl
-    WWW:           http://www.swi-prolog.org/projects/xpce/
+    WWW:           http://www.swi-prolog.org/packages/xpce/
     Copyright (c)  2003-2013, University of Amsterdam
                               VU University Amsterdam
     All rights reserved.

--- a/prolog/lib/pce_require.pl
+++ b/prolog/lib/pce_require.pl
@@ -2,7 +2,7 @@
 
     Author:        Jan Wielemaker and Anjo Anjewierden
     E-mail:        J.Wielemaker@vu.nl
-    WWW:           http://www.swi-prolog.org/projects/xpce/
+    WWW:           http://www.swi-prolog.org/packages/xpce/
     Copyright (c)  1985-2011, University of Amsterdam
                               VU University Amsterdam
     All rights reserved.

--- a/prolog/lib/persistent_frame.pl
+++ b/prolog/lib/persistent_frame.pl
@@ -2,7 +2,7 @@
 
     Author:        Jan Wielemaker and Anjo Anjewierden
     E-mail:        J.Wielemaker@cs.vu.nl
-    WWW:           http://www.swi-prolog.org/projects/xpce/
+    WWW:           http://www.swi-prolog.org/packages/xpce/
     Copyright (c)  2002-2013, University of Amsterdam
                               VU University Amsterdam
     All rights reserved.

--- a/prolog/lib/portray_object.pl
+++ b/prolog/lib/portray_object.pl
@@ -2,7 +2,7 @@
 
     Author:        Jan Wielemaker and Anjo Anjewierden
     E-mail:        wielemak@science.uva.nl
-    WWW:           http://www.swi-prolog.org/projects/xpce/
+    WWW:           http://www.swi-prolog.org/packages/xpce/
     Copyright (c)  1985-2007, University of Amsterdam
     All rights reserved.
 

--- a/prolog/lib/swi_compatibility.pl
+++ b/prolog/lib/swi_compatibility.pl
@@ -2,7 +2,7 @@
 
     Author:        Jan Wielemaker and Anjo Anjewierden
     E-mail:        J.Wielemaker@vu.nl
-    WWW:           http://www.swi-prolog.org/projects/xpce/
+    WWW:           http://www.swi-prolog.org/packages/xpce/
     Copyright (c)  1996-2012, University of Amsterdam
                               VU University Amsterdam
     All rights reserved.

--- a/prolog/lib/trace/gui.pl
+++ b/prolog/lib/trace/gui.pl
@@ -2,7 +2,7 @@
 
     Author:        Jan Wielemaker and Anjo Anjewierden
     E-mail:        J.Wielemaker@vu.nl
-    WWW:           http://www.swi-prolog/projects/xpce/
+    WWW:           http://www.swi-prolog.org/projects/xpce/
     Copyright (c)  2001-2021, University of Amsterdam
                               VU University Amsterdam
                               SWI-Prolog Solutions b.v.

--- a/prolog/lib/trace/gui.pl
+++ b/prolog/lib/trace/gui.pl
@@ -2,7 +2,7 @@
 
     Author:        Jan Wielemaker and Anjo Anjewierden
     E-mail:        J.Wielemaker@vu.nl
-    WWW:           http://www.swi-prolog.org/projects/xpce/
+    WWW:           http://www.swi-prolog.org/packages/xpce/
     Copyright (c)  2001-2021, University of Amsterdam
                               VU University Amsterdam
                               SWI-Prolog Solutions b.v.

--- a/prolog/lib/trace/source.pl
+++ b/prolog/lib/trace/source.pl
@@ -2,7 +2,7 @@
 
     Author:        Jan Wielemaker and Anjo Anjewierden
     E-mail:        J.Wielemaker@vu.nl
-    WWW:           http://www.swi-prolog.org/projects/xpce/
+    WWW:           http://www.swi-prolog.org/packages/xpce/
     Copyright (c)  2001-2018, University of Amsterdam
                               VU University Amsterdam
     All rights reserved.

--- a/prolog/lib/trace/stack.pl
+++ b/prolog/lib/trace/stack.pl
@@ -2,7 +2,7 @@
 
     Author:        Jan Wielemaker and Anjo Anjewierden
     E-mail:        J.Wielemaker@vu.nl
-    WWW:           http://www.swi-prolog.org/projects/xpce/
+    WWW:           http://www.swi-prolog.org/packages/xpce/
     Copyright (c)  2001-2018, University of Amsterdam
                               VU University Amsterdam
     All rights reserved.

--- a/prolog/lib/trace/trace.pl
+++ b/prolog/lib/trace/trace.pl
@@ -2,7 +2,7 @@
 
     Author:        Jan Wielemaker and Anjo Anjewierden
     E-mail:        J.Wielemaker@vu.nl
-    WWW:           http://www.swi-prolog.org/projects/xpce/
+    WWW:           http://www.swi-prolog.org/packages/xpce/
     Copyright (c)  2001-2016, University of Amsterdam
                               VU University Amsterdam
     All rights reserved.

--- a/prolog/lib/trace/util.pl
+++ b/prolog/lib/trace/util.pl
@@ -2,7 +2,7 @@
 
     Author:        Jan Wielemaker and Anjo Anjewierden
     E-mail:        J.Wielemaker@vu.nl
-    WWW:           http://www.swi-prolog.org/projects/xpce/
+    WWW:           http://www.swi-prolog.org/packages/xpce/
     Copyright (c)  2001-2020, University of Amsterdam
                               VU University Amsterdam
                               CWI, Amsterdam

--- a/src/ari/expression.c
+++ b/src/ari/expression.c
@@ -2,7 +2,7 @@
 
     Author:        Jan Wielemaker and Anjo Anjewierden
     E-mail:        J.Wielemaker@cs.vu.nl
-    WWW:           http://www.swi-prolog.org/projects/xpce/
+    WWW:           http://www.swi-prolog.org/packages/xpce/
     Copyright (c)  1985-2011, University of Amsterdam
                               VU University Amsterdam
     All rights reserved.

--- a/src/gra/postscript.c
+++ b/src/gra/postscript.c
@@ -2,7 +2,7 @@
 
     Author:        Jan Wielemaker and Anjo Anjewierden
     E-mail:        wielemak@science.uva.nl
-    WWW:           http://www.swi-prolog.org/projects/xpce/
+    WWW:           http://www.swi-prolog.org/packages/xpce/
     Copyright (c)  1985-2005, University of Amsterdam
     All rights reserved.
 

--- a/src/h/arith.h
+++ b/src/h/arith.h
@@ -2,7 +2,7 @@
 
     Author:        Jan Wielemaker and Anjo Anjewierden
     E-mail:        J.Wielemaker@cs.vu.nl
-    WWW:           http://www.swi-prolog.org/projects/xpce/
+    WWW:           http://www.swi-prolog.org/packages/xpce/
     Copyright (c)  1985-2011, University of Amsterdam
                               VU University Amsterdam
     All rights reserved.

--- a/src/itf/asfile.c
+++ b/src/itf/asfile.c
@@ -2,7 +2,7 @@
 
     Author:        Jan Wielemaker and Anjo Anjewierden
     E-mail:        wielemak@science.uva.nl
-    WWW:           http://www.swi-prolog.org/projects/xpce/
+    WWW:           http://www.swi-prolog.org/packages/xpce/
     Copyright (c)  1995-2013, University of Amsterdam
     All rights reserved.
 

--- a/src/itf/cpp.cxx
+++ b/src/itf/cpp.cxx
@@ -2,7 +2,7 @@
 
     Author:        Jan Wielemaker and Anjo Anjewierden
     E-mail:        wielemak@science.uva.nl
-    WWW:           http://www.swi-prolog.org/projects/xpce/
+    WWW:           http://www.swi-prolog.org/packages/xpce/
     Copyright (c)  1985-2007, University of Amsterdam
     All rights reserved.
 

--- a/src/itf/main.cxx
+++ b/src/itf/main.cxx
@@ -2,7 +2,7 @@
 
     Author:        Jan Wielemaker and Anjo Anjewierden
     E-mail:        wielemak@science.uva.nl
-    WWW:           http://www.swi-prolog.org/projects/xpce/
+    WWW:           http://www.swi-prolog.org/packages/xpce/
     Copyright (c)  1997-2016, University of Amsterdam
     All rights reserved.
 

--- a/src/ker/alloc.c
+++ b/src/ker/alloc.c
@@ -2,7 +2,7 @@
 
     Author:        Jan Wielemaker and Anjo Anjewierden
     E-mail:        J.Wielemaker@vu,nl
-    WWW:           http://www.swi-prolog.org/projects/xpce/
+    WWW:           http://www.swi-prolog.org/packages/xpce/
     Copyright (c)  1985-2012, University of Amsterdam
                               VU University Amsterdam
     All rights reserved.

--- a/src/msw/msimage.c
+++ b/src/msw/msimage.c
@@ -2,7 +2,7 @@
 
     Author:        Jan Wielemaker and Anjo Anjewierden
     E-mail:        J.Wielemaker@vu.nl
-    WWW:           http://www.swi-prolog.org/projects/xpce/
+    WWW:           http://www.swi-prolog.org/packages/xpce/
     Copyright (c)  1995-2013, University of Amsterdam
                               VU University Amsterdam
     All rights reserved.

--- a/src/txt/editor.c
+++ b/src/txt/editor.c
@@ -2,7 +2,7 @@
 
     Author:        Jan Wielemaker and Anjo Anjewierden
     E-mail:        J.Wielemaker@cs.nl
-    WWW:           http://www.swi-prolog.org/projects/xpce/
+    WWW:           http://www.swi-prolog.org/packages/xpce/
     Copyright (c)  1985-2017, University of Amsterdam
                               VU University Amsterdam
     All rights reserved.

--- a/swipl/link.c
+++ b/swipl/link.c
@@ -2,7 +2,7 @@
 
     Author:        Jan Wielemaker and Anjo Anjewierden
     E-mail:        wielemak@science.uva.nl
-    WWW:           http://www.swi-prolog.org/projects/xpce/
+    WWW:           http://www.swi-prolog.org/packages/xpce/
     Copyright (c)  2011-2016, University of Amsterdam
     All rights reserved.
 

--- a/swipl/pcecall.c
+++ b/swipl/pcecall.c
@@ -2,7 +2,7 @@
 
     Author:        Jan Wielemaker and Anjo Anjewierden
     E-mail:        J.Wielemaker@cs.vu.nl
-    WWW:           http://www.swi-prolog.org/projects/xpce/
+    WWW:           http://www.swi-prolog.org/packages/xpce/
     Copyright (c)  2011-2015, University of Amsterdam
                               VU University Amsterdam
     All rights reserved.

--- a/swipl/table.c
+++ b/swipl/table.c
@@ -2,7 +2,7 @@
 
     Author:        Jan Wielemaker and Anjo Anjewierden
     E-mail:        wielemak@science.uva.nl
-    WWW:           http://www.swi-prolog.org/projects/xpce/
+    WWW:           http://www.swi-prolog.org/packages/xpce/
     Copyright (c)  2011-2016, University of Amsterdam
     All rights reserved.
 

--- a/swipl/xpce-stub.c
+++ b/swipl/xpce-stub.c
@@ -2,7 +2,7 @@
 
     Author:        Jan Wielemaker and Anjo Anjewierden
     E-mail:        wielemak@science.uva.nl
-    WWW:           http://www.swi-prolog.org/projects/xpce/
+    WWW:           http://www.swi-prolog.org/packages/xpce/
     Copyright (c)  2011-2016, University of Amsterdam
     All rights reserved.
 


### PR DESCRIPTION
There were several issues with the links given in the source code annotations which I fixed:
- Add missing `.org` suffix in `prolog/lib/trace/gui.pl`
- Correct link from `www-` to `www.` in `prolog/lib/english/pce_messages.pl`
- Replace all URLs `www.swi-prolog.org/projects` by `www.swi-prolog.org/packages` to fix legacy link http://www.swi-prolog.org/projects/xpce/ via sed:
    ```sh
    find . -type f -exec sed -i 's/www.swi-prolog.org\/projects/www.swi-prolog.org\/packages/g' {} \;
    ```

It's 2021, so I would also prefer to replace all `http://www.swi-prolog.org` by `https://www.swi-prolog.org` (with https), but that's up to you :)