### PR TITLE
avoid breaking build without GUI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,4 +193,6 @@ foreach(rc ${XPCE_LINK_RC})
 	  RENAME ${rc}.rc)
 endforeach()
 
+else(HAVE_GUI)
+add_custom_target(pl2xpce COMMENT "dummy target to avoid breaking build without GUI")
 endif(HAVE_GUI)


### PR DESCRIPTION
When building master branch of https://github.com/SWI-Prolog/swipl-devel without GUI (no X11 libs) I'm getting this error:
```
make[2]: *** No rule to make target 'man/pl2xpce', needed by 'man/lib/main.tex'.  Stop.
```
I'm not sure if this dummy cmake target is the best way to fix it.