### PR TITLE
workaround to suppress a warning from gcc

### DIFF
--- a/src/win/window.c
+++ b/src/win/window.c
@@ -701,12 +701,13 @@ postEventWindow(PceWindow sw, EventObj ev)
     goto out;
   }
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Warray-bounds"
-  if ( sw->focus != (Graphical) sw || notNil(sw->focus_recogniser) )
-  { rval = send(sw, NAME_event, ev, EAV);
+  /* This code looks a bit awkward, but prevents a -Warray-bounds warning from gcc */
+  if(notNil(sw->focus))
+  { if ( sw->focus != (Graphical) sw || notNil(sw->focus_recogniser) )
+      rval = send(sw, NAME_event, ev, EAV);
   }
-#pragma GCC diagnostic pop
+  else
+    rval = send(sw, NAME_event, ev, EAV);
 
   if ( !rval )
   { ScrollBar sb;


### PR DESCRIPTION
and avoid a pragma at the same time

Starting point:
 
  if ( sw->focus != (Graphical) sw || notNil(sw->focus_recogniser) ) // warning
  { rval = send(sw, NAME_event, ev, EAV);
  }
 
1. I’ll duplicate the code, once for notNil(sw->focus) and once for isNil(sw->focus). This is inspired by a few lines above (l. 678):
 
  if(notNil(sw->focus))
  { if ( sw->focus != (Graphical) sw || notNil(sw->focus_recogniser) ) // no warning, similar to l. 678
      rval = send(sw, NAME_event, ev, EAV);
  }
 
  if(isNil(sw->focus))
  { if ( sw->focus != (Graphical) sw || notNil(sw->focus_recogniser) ) // warning
      rval = send(sw, NAME_event, ev, EAV);
  }
 
2. If sw->focus is Nil (= zero), it differs from sw which cannot be zero, so sw->focus != (Graphical) sw succeeds, and so does the whole condition with the ||:
 
  if(notNil(sw->focus))
  { if ( sw->focus != (Graphical) sw || notNil(sw->focus_recogniser) )
      rval = send(sw, NAME_event, ev, EAV);
  }
 
  if(isNil(sw->focus))
    rval = send(sw, NAME_event, ev, EAV);
 
3. We can actually change this into an if-else (then „send“ is definitely not called twice):
 
  if(notNil(sw->focus))
  { if ( sw->focus != (Graphical) sw || notNil(sw->focus_recogniser) )
      rval = send(sw, NAME_event, ev, EAV);
  }
  else
    rval = send(sw, NAME_event, ev, EAV);
 
Warning has disappeared. 
