### PR TITLE
replace most of expand_path/2 internals with absolute_file_name/3

### DIFF
--- a/prolog/lib/emacs/prolog_mode.pl
+++ b/prolog/lib/emacs/prolog_mode.pl
@@ -278,10 +278,7 @@ expand_path(X, X) :-
     atomic(X),
     !.
 expand_path(Term, D) :-
-    Term =.. [New, Sub],
-    user:file_search_path(New, D0),
-    expand_path(D0, D1),
-    atomic_list_concat([D1, /, Sub], D).
+   absolute_file_name(Term,D,[]).
 
 
 :- pce_group(indent).


### PR DESCRIPTION
old code could not handle aliases like swi(library/clp) only swi('library/clp').
Now the XpceManual/Tools work better, for example Visual Hierarchy's nodes all get opened  