### PR TITLE
FIX: conflicting declarations

### DIFF
--- a/deps/xpm/create.c
+++ b/deps/xpm/create.c
@@ -220,7 +220,7 @@ typedef struct {
 static int
 AllocColor(display, colormap, colorname, xcolor, closure)
     Display *display;
-    Colormap *colormap;
+    Colormap colormap;
     char *colorname;
     XColor *xcolor;
     void *closure;		/* not used */


### PR DESCRIPTION
noticed only by clang (not gcc)