### PR TITLE
initial implementation of arc with cairo

### DIFF
--- a/src/gra/arc.c
+++ b/src/gra/arc.c
@@ -99,43 +99,11 @@ RedrawAreaArc(ArcObj a, Area area)
   r_thickness(valInt(a->pen));
   r_dash(a->texture);
 
-#ifndef WIN32_GRAPHICS
-  r_arcmode(a->close == NAME_none ? NAME_pieSlice : a->close);
-  r_arc(valInt(a->position->x) - aw, valInt(a->position->y) - ah,
+  r_arc(cx - aw, cy - ah,
 	2*aw, 2*ah,
-	rfloat(valReal(a->start_angle)*64.0), rfloat(valReal(a->size_angle)*64.0),
+	rfloat(valReal(a->start_angle)), rfloat(valReal(a->size_angle)),
+	a->close,
 	a->fill_pattern);
-
-  if ( a->close != NAME_none && a->pen != ZERO )
-  { if ( a->close == NAME_chord )
-    { r_line(sx, sy, ex, ey);
-    } else /* if ( a->close == NAME_pieSlice ) */
-    { r_line(cx, cy, sx, sy);
-      r_line(cx, cy, ex, ey);
-    }
-  }
-
-#else /*WIN32_GRAPHICS*/
-
-{ int ax, ay, bx, by;
-  double sa = valReal(a->size_angle);
-  int large;
-
-  if ( sa >= 0.0 )
-  { ax = sx, ay = sy, bx = ex, by = ey;
-    large = (sa >= 180.0);
-  } else
-  { ax = ex, ay = ey, bx = sx, by = sy;
-    large = (sa <= -180.0);
-  }
-
-  r_msarc(valInt(a->position->x) - aw, valInt(a->position->y) - ah,
-	  2*aw, 2*ah,
-	  ax, ay, bx, by, large,
-	  a->close, a->fill_pattern);
-}
-
-#endif /* __WINDOWS__ */
 
   if (notNil(a->first_arrow))
   { Any av[4];

--- a/src/gra/graphical.c
+++ b/src/gra/graphical.c
@@ -3158,13 +3158,13 @@ static status
 drawArcGraphical(Graphical gr,		/* has to handle mode */
 		 Int x, Int y, Int w, Int h,
 		 Real start, Real end, Any fill)
-{ int s = (isDefault(start) ? 0      : rfloat(valReal(start) * 64.0));
-  int e = (isDefault(end)   ? 360*64 : rfloat(valReal(end) * 64.0));
+{ int s = (isDefault(start) ? 0   : rfloat(valReal(start)));
+  int e = (isDefault(end)   ? 360 : rfloat(valReal(end)));
 
   if ( isDefault(fill) )
     fill = NIL;
 
-  r_arc(valInt(x), valInt(y), valInt(w), valInt(h), s, e, fill);
+  r_arc(valInt(x), valInt(y), valInt(w), valInt(h), s, e, NAME_none, fill);
 
   succeed;
 }

--- a/src/sdl/sdldraw.c
+++ b/src/sdl/sdldraw.c
@@ -1129,7 +1129,7 @@ r_3d_diamond(int x, int y, int w, int h, Elevation e, int up)
 }
 
 /**
- * Draw an arc within a specified rectangle.
+ * Draw an arc within a specified rectangle in the clockwise direction.
  *
  * @param x The x-coordinate of the top-left corner of the bounding rectangle.
  * @param y The y-coordinate of the top-left corner of the bounding rectangle.
@@ -1137,11 +1137,37 @@ r_3d_diamond(int x, int y, int w, int h, Elevation e, int up)
  * @param h The height of the bounding rectangle.
  * @param s The starting angle of the arc.
  * @param e The ending angle of the arc.
+ * @param close {none, chord, pie_slice}
  * @param fill The fill pattern or color.
  */
 void
-r_arc(int x, int y, int w, int h, int s, int e, Any fill)
-{
+r_arc(int x, int y, int w, int h, int s, int e, Name close, Any fill)
+{ Translate(x, y);
+  NormaliseArea(x, y, w, h);
+  FloatArea(x, y, w, h);
+  double fs = s * M_PI / 180.0;
+  double fe = e * M_PI / 180.0;
+
+  cairo_save(CR);
+  cairo_translate(CR, fx + fw / 2.0, fy + fh / 2.0);  // Move to center
+  cairo_scale(CR, fw / 2.0, fh / 2.0);              // Scale unit circle
+  if (close == NAME_pieSlice)
+  { cairo_move_to(CR, 0, 0);
+  }
+  cairo_arc(CR, 0, 0, 1.0, fs, fe);
+  cairo_restore(CR);
+  if (close == NAME_pieSlice || close == NAME_chord)
+  { cairo_close_path(CR);
+  }
+  if ( notNil(fill) )
+  { r_fillpattern(fill, NAME_foreground);
+    pce_cairo_set_source_color(CR, context.fill_pattern);
+    cairo_fill_preserve(CR);
+  }
+  if ( context.pen )
+  { pce_cairo_set_source_color(CR, context.colour);
+    cairo_stroke(CR);
+  }
 }
 
 /**
@@ -1155,28 +1181,7 @@ r_arc(int x, int y, int w, int h, int s, int e, Any fill)
  */
 void
 r_ellipse(int x, int y, int w, int h, Any fill)
-{ Translate(x, y);
-  NormaliseArea(x, y, w, h);
-  FloatArea(x, y, w, h);
-
-  DEBUG(NAME_draw,
-	Cprintf("r_ellipse(%d, %d, %d, %d, %s)\n",
-		x, y, w, h, pp(fill)));
-
-  cairo_save(CR);
-  cairo_translate(CR, fx + fw / 2.0, fy + fh / 2.0);  // Move to center
-  cairo_scale(CR, fw / 2.0, fh / 2.0);              // Scale unit circle
-  cairo_arc(CR, 0, 0, 1.0, 0, 2 * M_PI);
-  cairo_restore(CR);
-  if ( notNil(fill) )
-  { r_fillpattern(fill, NAME_foreground);
-    pce_cairo_set_source_color(CR, context.fill_pattern);
-    cairo_fill_preserve(CR);
-  }
-  if ( context.pen )
-  { pce_cairo_set_source_color(CR, context.colour);
-    cairo_stroke(CR);
-  }
+{ r_arc(x, y, w, h, 0, 360, NAME_none, fill);
 }
 
 /**

--- a/src/sdl/sdldraw.h
+++ b/src/sdl/sdldraw.h
@@ -84,7 +84,7 @@ void r_3d_box(int x, int y, int w, int h, int radius, Elevation e, int up);
 void r_3d_line(int x1, int y1, int x2, int y2, Elevation e, int up);
 void r_3d_triangle(int x1, int y1, int x2, int y2, int x3, int y3, Elevation e, int up, int map);
 void r_3d_diamond(int x, int y, int w, int h, Elevation e, int up);
-void r_arc(int x, int y, int w, int h, int s, int e, Any fill);
+void r_arc(int x, int y, int w, int h, int s, int e, Name close, Any fill);
 void r_ellipse(int x, int y, int w, int h, Any fill);
 void r_3d_ellipse(int x, int y, int w, int h, Elevation z, int up);
 void r_line(int x1, int y1, int x2, int y2);

--- a/src/x11/wstproto.h
+++ b/src/x11/wstproto.h
@@ -99,7 +99,7 @@ COMMON(void)	r_3d_box(int x, int y, int w, int h, int radius, Elevation e, int u
 COMMON(void)	r_3d_line(int x1, int y1, int x2, int y2, Elevation e, int up);
 COMMON(void)	r_3d_triangle(int x1, int y1, int x2, int y2, int x3, int y3, Elevation e, int up, int map);
 COMMON(void)	r_3d_diamond(int x, int y, int w, int h, Elevation e, int up);
-COMMON(void)	r_arc(int x, int y, int w, int h, int s, int e, Any fill);
+COMMON(void)	r_arc(int x, int y, int w, int h, int s, int e, Name close, Any fill);
 COMMON(void)	r_ellipse(int x, int y, int w, int h, Any fill);
 COMMON(void)	r_3d_ellipse(int x, int y, int w, int h, Elevation z, int up);
 COMMON(void)	r_line(int x1, int y1, int x2, int y2);


### PR DESCRIPTION
Use the existing implementation of ellipse and generalize it for arcs.
Therefore, I reused the `r_arc` function for `r_ellipse`.

I have noticed that drawing ellipse in pcedraw leaves some trails:
![image](https://github.com/user-attachments/assets/5d1000c5-08fa-4a87-af94-733605d2b2cb)

Do you think this is a problem with the implementation or is it something to do with int coordinates ?
Maybe just a bug in pcedraw ?

Anyway, let me know what you think :)