### PR TITLE
set app metadata

### DIFF
--- a/src/sdl/sdl.c
+++ b/src/sdl/sdl.c
@@ -56,6 +56,14 @@ setPceThread(void)
   { sdl_main_thread = PL_thread_self();
     DEBUG(NAME_thread,
 	  Cprintf("SDL_Init() on thread %d\n", sdl_main_thread));
+
+    SDL_SetAppMetadataProperty(SDL_PROP_APP_METADATA_NAME_STRING, "xpce");
+    SDL_SetAppMetadataProperty(SDL_PROP_APP_METADATA_VERSION_STRING, PCE_VERSION);
+    SDL_SetAppMetadataProperty(SDL_PROP_APP_METADATA_IDENTIFIER_STRING, "org.swi_prolog.xpce");
+    SDL_SetAppMetadataProperty(SDL_PROP_APP_METADATA_CREATOR_STRING, "Jan Wielemaker,Anjo Anjewierden");
+    SDL_SetAppMetadataProperty(SDL_PROP_APP_METADATA_COPYRIGHT_STRING, "Copyright 1992-2007, University of Amsterdam");
+    SDL_SetAppMetadataProperty(SDL_PROP_APP_METADATA_URL_STRING, "http://www.swi-prolog.org/packages/xpce/");
+
     if ( !SDL_Init(SDL_INIT_EVENTS|SDL_INIT_VIDEO) )
       return errorPce(NIL, NAME_sdlInitialize);
     ChangedFrames = globalObject(NAME_changedFrames, ClassChain, EAV);


### PR DESCRIPTION
I'm not sure of the various information like the app identifier or name.

One thing I have noticed is that setting a app identifier `SDL_PROP_APP_METADATA_IDENTIFIER_STRING` causes all xpce windows to be grouped in my taskbar in kde plasma.
I'm not sure this is the behaviour we want ?