### PR TITLE
FIX: Debug build resource loading in sdlimage.c

### DIFF
--- a/src/sdl/sdlimage.c
+++ b/src/sdl/sdlimage.c
@@ -255,7 +255,7 @@ ws_load_image_file(Image image)
     fail;
   cairo_surface_t *final = my_cairo_copy_surface(surf);
   cairo_surface_destroy(surf);
-  if ( !my_cairo_check_surface(final, surf) )
+  if ( !my_cairo_check_surface(image, final) )
     fail;
 
   if ( isbitmap )


### PR DESCRIPTION
Use-after-free bug: cairo_surface_destroy(surf) freed the pointer, then my_cairo_check_surface() received the freed memory instead of the valid 'final' surface. This caused Debug builds to fail resource loading while Release builds happened to work.