### PR TITLE
1494 ws_dispatch() caches external stream fds as the default dispatch fd

### DIFF
--- a/src/h/interface.h
+++ b/src/h/interface.h
@@ -438,6 +438,7 @@ __pce_export int	pceInstanceOf(PceObject obj, PceObject class);
 #define PCE_DISPATCH_TIMEOUT	(1)
 
 __pce_export int	pceDispatch(IOSTREAM *fd, int msecs);
+__pce_export void	pceSetDispatchInput(IOSTREAM *input);
 __pce_export void	pceRedraw(void);
 				/* context is an XtAppContext pointer */
 __pce_export void *     pceXtAppContext(void * context);

--- a/src/itf/interface.c
+++ b/src/itf/interface.c
@@ -670,6 +670,12 @@ pceDispatch(IOSTREAM *input, int time)
 
 
 void
+pceSetDispatchInput(IOSTREAM *input)
+{ setDispatchInput(input);
+}
+
+
+void
 pceRedraw(void)
 { static DisplayManager dm = NULL;
 

--- a/src/sdl/sdlevent.c
+++ b/src/sdl/sdlevent.c
@@ -622,13 +622,41 @@ dispatch_event(EventObj ev)
  * mechanism to its initial state. It is typically called before
  * starting a new event loop or when reinitializing the event system.
  */
-void
-resetDispatch(void)
-{
-}
-
+static IOSTREAM *dispatch_input = NULL;
 static waitable_t dispatch_fd = NO_WAITABLE;
 static FDWatch *watch  = NULL;
+
+void
+resetDispatch(void)
+{ if ( watch )
+  { remove_fd_watch(watch);
+    watch = NULL;
+  }
+
+  dispatch_input = NULL;
+  dispatch_fd = NO_WAITABLE;
+}
+
+void
+setDispatchInput(IOSTREAM *input)
+{ waitable_t fd;
+
+  if ( input )
+  {
+#if __WINDOWS__
+    fd = Swinhandle(input);
+#else
+    fd = Sfileno(input);
+#endif
+  } else
+    fd = NO_WAITABLE;
+
+  if ( input != dispatch_input || fd != dispatch_fd )
+  { resetDispatch();
+    dispatch_input = input;
+    dispatch_fd = fd;
+  }
+}
 
 static void
 set_watch(waitable_t fd)
@@ -704,11 +732,14 @@ status
 ws_dispatch(IOSTREAM *input, Any timeout)
 { int tmo;
   waitable_t fd;
+  bool persistent = false;
+  FDWatch *wait_watch = NULL;
 
   if ( !input )
   { fd = NO_WAITABLE;
   } else if ( input == DEFAULT )
   { fd = dispatch_fd;
+    persistent = true;
   } else
   {
 #if __WINDOWS__
@@ -716,10 +747,9 @@ ws_dispatch(IOSTREAM *input, Any timeout)
 #else
     fd = Sfileno(input);
 #endif
+    if ( input == dispatch_input && fd == dispatch_fd )
+      persistent = true;
   }
-
-  if ( fd != NO_WAITABLE )
-    dispatch_fd = fd;
 
   if ( isNil(timeout) )
   { tmo = -1;
@@ -747,7 +777,12 @@ ws_dispatch(IOSTREAM *input, Any timeout)
       succeed;
 
     if ( fd != NO_WAITABLE )
-      set_watch(fd);
+    { if ( persistent )
+      { set_watch(fd);
+      } else
+      { wait_watch = add_fd_to_watch(fd, FD_READY_DISPATCH, NULL);
+      }
+    }
 
     bool rc;
     SDL_Event ev;
@@ -760,15 +795,34 @@ ws_dispatch(IOSTREAM *input, Any timeout)
     if ( rc )
     { if ( ev.type == MY_EVENT_FD_READY &&
 	   ev.user.code == FD_READY_DISPATCH )
-      { FDWatch *watch = ev.user.data1;
-	cmp_and_set_watch(watch, WATCH_PENDING, WATCH_PROCESSING);
+      { FDWatch *evwatch = ev.user.data1;
+
+	if ( wait_watch && evwatch == wait_watch )
+	{ remove_fd_watch(wait_watch);
+	  wait_watch = NULL;
+	} else if ( evwatch == watch )
+	{ cmp_and_set_watch(evwatch, WATCH_PENDING, WATCH_PROCESSING);
+	}
+
+	if ( wait_watch )
+	{ remove_fd_watch(wait_watch);
+	  wait_watch = NULL;
+	}
 	succeed;
+      }
+
+      if ( wait_watch )
+      { remove_fd_watch(wait_watch);
+	wait_watch = NULL;
       }
 
       EventObj event = CtoEvent(&ev);
       if ( event )
 	dispatch_event(event);
     }
+
+    if ( wait_watch )
+      remove_fd_watch(wait_watch);
 
     considerLocStillEvent();
 

--- a/src/sdl/sdlevent.h
+++ b/src/sdl/sdlevent.h
@@ -43,6 +43,7 @@ PceWindow ws_grabbing_window(void);
 
 /* Public interface */
 void resetDispatch(void);
+void setDispatchInput(IOSTREAM *input);
 status ws_dispatch(IOSTREAM *input, Any timeout);
 void ws_discard_input(const char *msg);
 Any ws_event_in_subwindow(EventObj ev, Any root);

--- a/swipl/interface.c
+++ b/swipl/interface.c
@@ -2850,7 +2850,20 @@ the possibility of reentrance at moments this is not allowed in PCE ...
 
 static int
 pce_dispatch(IOSTREAM *fd)
-{ if ( pceDispatch(fd, TIMEOUT) == PCE_DISPATCH_INPUT )
+{ IOSTREAM *input = Suser_input;
+
+  if ( !input )
+    input = Sinput;
+
+  if ( fd == input )
+  { if ( PL_ttymode(fd) == PL_NOTTY )
+    { pceSetDispatchInput(NULL);
+    } else
+    { pceSetDispatchInput(fd);
+    }
+  }
+
+  if ( pceDispatch(fd, TIMEOUT) == PCE_DISPATCH_INPUT )
     return PROLOG_DISPATCH_INPUT;
 
   return PROLOG_DISPATCH_TIMEOUT;


### PR DESCRIPTION
Proposed fix for [1494 ws_dispatch() caches external stream fds as the default](https://github.com/SWI-Prolog/swipl-devel/issues/1494)

This PR was heavily AI-assisted as I'm not familiar with the code so I must inject a note of caution.

The initial attempt at a fix resulted in a SEGV because as well as stopping caching of external fds, it also changed user_input/console from the old persistent watch path to a temporary add/remove watch path. Testing with my app under `gspy` triggered a SEGV in `el_unwrap()` / `el_end()`, which my app also uses. This was apparently because the GUI debugger/libedit path depends on the old console behaviour.

This patch makes `dispatch_fd` explicitly owned,  only `pce_dispatch()` can register the console/default input as the persistent dispatch fd. So, In `ws_dispatch()`:

* `DEFAULT` and the registered console input use the old persistent `set_watch()` path.
* Other concrete streams/fds are watched temporarily for just that one dispatch call.
* External fds no longer modify `dispatch_fd`.

This removes the old incorrect setting of `dispatch_fd` to any and all fds to just the fd of the console, so (for example) poll ops on a closed fd will no longer fail, whist not changing the existing "This is the default (console) fd" mechanism.

I've tested as follows:

* The console flood of `Confirmer running; discarding input ...failed` messages is gone.
* Tracing with `strace` after socket/HTTP activity no longer shows repeated `POLLNVAL` from a known-closed external fd.
* Existing xpce CTest passes: `ctest --test-dir /data2/tmp/swipl-devel-10.1.7/build -R '^xpce:xpce$' --output-on-failure`
* A manual test with my app under gspy no longer triggers the `el_unwrap()` / `el_end()` SEGV caused by the first patch attempt.
* Pressing keys in the console while the graphical debugger confirmer is active still produces `Confirmer running; discarding input ...ok`, which appears to be existing behaviour for the console/default input.

**NOTE: This has only been tested on Linux.**
